### PR TITLE
Update version of Capsule and the plugin itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ With gradle 2.1+, simply define the plugins at the top of your build script:
 
 ```groovy
 plugins {
-  id "us.kirchmeier.capsule" version "1.0-rc1"
+  id "us.kirchmeier.capsule" version "1.0.1"
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=us.kirchmeier
 baseName=gradle-capsule-plugin
-version=1.0.0
+version=1.0.1

--- a/src/main/groovy/us/kirchmeier/capsule/CapsuleGradlePlugin.groovy
+++ b/src/main/groovy/us/kirchmeier/capsule/CapsuleGradlePlugin.groovy
@@ -24,7 +24,7 @@ class CapsuleGradlePlugin implements Plugin<Project> {
       configurations.mavenCaplet.extendsFrom(configurations.caplet)
 
       def capsuleExt = project.extensions.create("capsule", CapsuleGradleExtension, project)
-      capsuleExt.version = '1.0'
+      capsuleExt.version = '1.0.1'
     }
   }
 


### PR DESCRIPTION
Ran the tests...but they didn't pass.
```console
./gradlew check
FAILURE: Build failed with an exception.

* Where:
Build file 'C:\git\gradle-capsule-plugin\build.gradle' line: 64

* What went wrong:
Execution failed for task ':testIntegration'.
> Cannot run program "C:\git\gradle-capsule-plugin/src/test/gradle/gradlew" (in directory "C:\git\gradle-capsule-plugin\src\test\gradle"): CreateProcess error=193, %1 is not a valid Win32 application

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED
```
I think it was just due to me running it on Windows....

Addresses issue https://github.com/danthegoodman/gradle-capsule-plugin/issues/16