### PR TITLE
Replacing File.renameTo with ant.move

### DIFF
--- a/src/main/groovy/us/kirchmeier/capsule/task/Capsule.groovy
+++ b/src/main/groovy/us/kirchmeier/capsule/task/Capsule.groovy
@@ -187,7 +187,7 @@ class Capsule extends Jar {
       }
     }
     ant.chmod(file: f, perm: 'ug+x', osfamily: 'unix')
-    f.renameTo(outputs.files.singleFile)
+    ant.move(file: f, tofile: outputs.files.singleFile)
   }
 
   protected String getNonConflictingEmbeddedName(String name){


### PR DESCRIPTION
File.renameTo fails silently on Linux across file systems.