### PR TITLE
Declare reallyExecutable.script as task's input

### DIFF
--- a/src/main/groovy/us/kirchmeier/capsule/spec/ReallyExecutableSpec.groovy
+++ b/src/main/groovy/us/kirchmeier/capsule/spec/ReallyExecutableSpec.groovy
@@ -1,12 +1,18 @@
 package us.kirchmeier.capsule.spec
 
 import org.gradle.api.Project
+import org.gradle.api.tasks.TaskInputs
 
 class ReallyExecutableSpec {
 
   File script
   protected boolean _regular = true
   protected boolean _trampoline = false
+  protected TaskInputs _taskInputs
+  
+  ReallyExecutableSpec(TaskInputs taskInputs) {
+    _taskInputs = taskInputs
+  }
 
   ReallyExecutableSpec regular() {
     _regular = true
@@ -43,6 +49,7 @@ class ReallyExecutableSpec {
 
   ReallyExecutableSpec script(File file) {
     script = file
+    _taskInputs.file script
     return this
   }
 

--- a/src/main/groovy/us/kirchmeier/capsule/task/Capsule.groovy
+++ b/src/main/groovy/us/kirchmeier/capsule/task/Capsule.groovy
@@ -107,7 +107,7 @@ class Capsule extends Jar {
 
   public ReallyExecutableSpec getReallyExecutable(){
     if(_reallyExecutable == null){
-      _reallyExecutable = new ReallyExecutableSpec();
+      _reallyExecutable = new ReallyExecutableSpec(inputs);
     }
     return _reallyExecutable;
   }


### PR DESCRIPTION
Gradle tracks inputs for each task to determine whether the task is _UP-TO-DATE_ or needs to be executed. `reallyExecutable.script` was not declared as an input file and reported any `Capsule` task as _UP-TO-DATE_ even though the script file was changed. Consequently Capsule jar was not generated in case only the script changed.

I don't know how I should test this. Any suggestions are welcome.