### PR TITLE
Run unit and integration tests on Wercker

### DIFF
--- a/integration_test.sh
+++ b/integration_test.sh
@@ -15,6 +15,7 @@ export SDKMAN_DIR=~/.sdkman
 cd src/test/gradle
 
 for grdlVersion in ${VERSIONS[*]}; do
+  sdk install gradle $grdlVersion
   sdk use gradle $grdlVersion
   gradle clean self-test
 done

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -14,12 +14,11 @@ export SDKMAN_DIR=~/.sdkman
 
 cd src/test/gradle
 
+RESULT=0
 for grdlVersion in ${VERSIONS[*]}; do
   sdk install gradle $grdlVersion
   sdk use gradle $grdlVersion
   gradle clean self-test
+  RESULT+=$?
 done
-
-
-
-
+exit $RESULT

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,23 @@
+box: {id: 'java:8-jdk-alpine', cmd: '/bin/sh'}
+
+check:
+  steps:
+  - script:
+      name: check plugin
+      code: |
+        apk --update add bash
+        ./gradlew check
+
+integration test:
+  steps:
+  - script:
+      name: install sdkman
+      code: |
+        apk --update add curl bash
+        curl -s "https://get.sdkman.io" | bash
+        echo 'sdkman_auto_answer=true' > ~/.sdkman/etc/config
+  - script:
+      name: integration test
+      code: |
+        apk --update add bash unzip libstdc++
+        ./integration_test.sh


### PR DESCRIPTION
This is an alternative solution to #28.

I realized that fighting Travis might not be the best idea. Instead I chose [Wercker][1] which runs jobs in docker containers thus fully isolated environment.

This solution has an advantage to #28 because it uses `./integration_test.sh` script to perform tests. I had to adjust the script to be suitable for CI environments by not making assumptions about installed Gradle versions as well as exiting with non-zero code when the one or more tests fail.

The disadvantage of Wercker in this case is that you would have to configure [workflow][2] (and [pipelines][3] before that) via web UI.

[1]: http://wercker.com/
[2]: http://devcenter.wercker.com/docs/workflows/index.html
[3]: http://devcenter.wercker.com/docs/pipelines/index.html